### PR TITLE
Updated package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ HAL is the lowest-level abstraction for the MATRIX Creator drivers. You can inte
 echo "deb http://packages.matrix.one/matrix-creator/ ./" | sudo tee --append /etc/apt/sources.list;
 sudo apt-get update;
 sudo apt-get upgrade;
-sudo apt-get install libmatrixio-creator-hal libmatrixio-creator-hal-dev
+sudo apt-get install libmatrix-creator-hal libmatrix-creator-hal-dev
 ```
 
 ## Install from source
@@ -17,7 +17,7 @@ sudo apt-get install libmatrixio-creator-hal libmatrixio-creator-hal-dev
 It does have some package dependencies, so please make sure to install the pre-requisites.
 
 ```
-sudo apt-get install cmake g++ git libfftw3-dev wiringpi matrixio-creator-init libgflags-dev
+sudo apt-get install cmake g++ git libfftw3-dev wiringpi matrix-creator-init libgflags-dev
 ```
 
 To start working with HAL directly, you'll need to run `sudo make install` to get the build running. 


### PR DESCRIPTION
replaced old package names to actual package names by replacing "matrixio" with "matrix".