### PR TITLE
everloop led order fixed

### DIFF
--- a/cpp/driver/everloop.cpp
+++ b/cpp/driver/everloop.cpp
@@ -34,8 +34,8 @@ bool Everloop::Write(const EverloopImage* led_image) {
 
   uint32_t led_offset = 0;
   for (const LedValue& led : led_image->leds) {
-    write_data[led_offset + 0] = led.red;
-    write_data[led_offset + 1] = led.green;
+    write_data[led_offset + 0] = led.green;
+    write_data[led_offset + 1] = led.red;
     write_data[led_offset + 2] = led.blue;
     write_data[led_offset + 3] = led.white;
     led_offset += 4;


### PR DESCRIPTION
(Now using the correct github account)
Unfortunately a small mistake has crept in with the speedup patch. Red and green are swapped.
Changed:
- green before red