### PR TITLE
fixed the stack buffer overflow in the bus read. 

### DIFF
--- a/cpp/driver/matrixio_bus.cpp
+++ b/cpp/driver/matrixio_bus.cpp
@@ -90,7 +90,7 @@ bool MatrixIOBus::Write(uint16_t add, uint16_t data) {
 }
 
 bool MatrixIOBus::Read(uint16_t add, uint16_t *data) {
-  return bus_driver_->Read(add, (unsigned char *)data, sizeof(data));
+  return bus_driver_->Read(add, (unsigned char *)data, sizeof(*data));
 }
 
 bool MatrixIOBus::GetMatrixName() {


### PR DESCRIPTION
The size was calculated on the pointer=4 and not on the actual size of uint16_t=2.