### PR TITLE
Change import

### DIFF
--- a/cpp/driver/microphone_core_fir.h
+++ b/cpp/driver/microphone_core_fir.h
@@ -1,5 +1,5 @@
 #include <valarray>
-#include "cpp/driver/microphone_core.h"
+#include "./microphone_core.h"
 
 namespace matrix_hal {
 


### PR DESCRIPTION
Change import so that in normal code user can import:
```language-cpp
#include "matrix_hal/microphone_core_fir.h"
// And then access default FIR filter with
matrix_hal::FIR_default[]
```