### PR TITLE
Allow raw audio collection from MicrophoneArray

### DIFF
--- a/cpp/driver/microphone_array.h
+++ b/cpp/driver/microphone_array.h
@@ -39,7 +39,7 @@ const uint16_t kMicrophoneChannels = 8;
 
 class MicrophoneArray : public MatrixDriver {
  public:
-  MicrophoneArray();
+  MicrophoneArray(bool enable_beamforming = true);
 
   ~MicrophoneArray();
 
@@ -58,10 +58,17 @@ class MicrophoneArray : public MatrixDriver {
     return kMicarrayBufferSize / kMicrophoneChannels;
   }
 
+  int16_t &Raw(int16_t sample, int16_t channel) {
+    return raw_data_[channel * NumberOfSamples() + sample];
+  }
+
   int16_t &At(int16_t sample, int16_t channel) {
+    if (!enable_beamforming_)
+      return Raw(sample, channel);
     return delayed_data_[sample * kMicrophoneChannels + channel];
   }
 
+  //call at own peril if beamforming is disabled
   int16_t &Beam(int16_t sample) { return beamformed_[sample]; }
 
   void CalculateDelays(float azimutal_angle, float polar_angle,
@@ -77,6 +84,7 @@ class MicrophoneArray : public MatrixDriver {
   std::valarray<int16_t> fir_coeff_;
   int16_t gain_;
   uint32_t sampling_frequency_;
+  bool enable_beamforming_;
 
   // beamforming delay and sum support
   std::valarray<CircularQueue<int16_t>> fifos_;

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -63,6 +63,13 @@ add_executable(micarray_recorder_direct micarray_recorder_direct.cpp)
   target_link_libraries(micarray_recorder_direct ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} ${CRYPT_LIB})
   target_link_libraries(micarray_recorder_direct ${GFLAGS_LIB})
 
+add_executable(micarray_raw_recorder_direct micarray_raw_recorder_direct.cpp)
+  set_property(TARGET micarray_raw_recorder_direct PROPERTY CXX_STANDARD 11)
+  target_link_libraries(micarray_raw_recorder_direct matrix_creator_hal)
+  target_link_libraries(micarray_raw_recorder_direct ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(micarray_raw_recorder_direct ${WIRINGPI_LIB} ${WIRINGPI_DEV_LIB} ${CRYPT_LIB})
+  target_link_libraries(micarray_raw_recorder_direct ${GFLAGS_LIB})
+
 add_executable(mic_demo_fir_direct mic_demo_fir_direct.cpp)
   set_property(TARGET mic_demo_fir_direct PROPERTY CXX_STANDARD 11)
   target_link_libraries(mic_demo_fir_direct matrix_creator_hal)

--- a/demos/micarray_raw_recorder_direct.cpp
+++ b/demos/micarray_raw_recorder_direct.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 <Admobilize>
+ * All rights reserved.
+ * 
+ * Modified 8/17/19 by founta to record raw audio
+ */
+
+#include <gflags/gflags.h>
+#include <wiringPi.h>
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <valarray>
+
+#include "../cpp/driver/everloop.h"
+#include "../cpp/driver/everloop_image.h"
+#include "../cpp/driver/matrixio_bus.h"
+#include "../cpp/driver/microphone_array.h"
+#include "../cpp/driver/microphone_core.h"
+
+DEFINE_int32(sampling_frequency, 16000, "Sampling Frequency");
+DEFINE_int32(duration, 5, "Interrupt after N seconds");
+DEFINE_int32(gain, -1, "Microphone Gain");
+
+namespace hal = matrix_hal;
+
+int main(int argc, char *agrv[]) {
+  google::ParseCommandLineFlags(&argc, &agrv, true);
+
+  hal::MatrixIOBus bus;
+  if (!bus.Init()) return false;
+
+  if (!bus.IsDirectBus()) {
+    std::cerr << "Kernel Modules has been loaded. Use ALSA implementation "
+              << std::endl;
+    return false;
+  }
+
+  int sampling_rate = FLAGS_sampling_frequency;
+  int seconds_to_record = FLAGS_duration;
+
+  // Microhone Array Configuration
+  hal::MicrophoneArray mics(false); //disable beamforming
+  mics.Setup(&bus);
+  mics.SetSamplingRate(sampling_rate);
+  if (FLAGS_gain > 0) mics.SetGain(FLAGS_gain);
+
+  mics.ShowConfiguration();
+  std::cout << "Duration : " << seconds_to_record << "s" << std::endl;
+
+  // Microphone Core Init
+  hal::MicrophoneCore mic_core(mics);
+  mic_core.Setup(&bus);
+
+  int16_t buffer[mics.Channels()]
+                [mics.SamplingRate() + mics.NumberOfSamples()];
+
+  std::ofstream os[mics.Channels()];
+
+  for (uint16_t c = 0; c < mics.Channels(); c++) {
+    std::string filename = "mic_" + std::to_string(mics.SamplingRate()) +
+                           "_raw_s16le_channel_" + std::to_string(c) + ".raw";
+    os[c].open(filename, std::ofstream::binary);
+  }
+
+  std::thread et(
+      [seconds_to_record](hal::MatrixIOBus *bus) {
+
+        hal::Everloop everloop;
+        everloop.Setup(bus);
+
+        hal::EverloopImage image(bus->MatrixLeds());
+
+        for (auto &led : image.leds) led.red = 10;
+        everloop.Write(&image);
+
+        int sleep = int(1000.0 * seconds_to_record / image.leds.size());
+
+        for (auto &led : image.leds) {
+          led.red = 0;
+          led.green = 10;
+
+          everloop.Write(&image);
+
+          std::this_thread::sleep_for(std::chrono::milliseconds(sleep));
+        }
+      },
+      &bus);
+
+  uint32_t samples = 0;
+  for (int s = 0; s < seconds_to_record; s++) {
+    for (;;) {
+      mics.Read(); /* Reading 8-mics buffer from de FPGA */
+
+      /* buffering */
+      for (uint32_t s = 0; s < mics.NumberOfSamples(); s++) {
+        for (uint16_t c = 0; c < mics.Channels(); c++) { /* mics.Channels()=8 */
+          buffer[c][samples] = mics.Raw(s, c);
+        }
+        samples++;
+      }
+
+      /* write to file */
+      if (samples >= mics.SamplingRate()) {
+        for (uint16_t c = 0; c < mics.Channels(); c++) {
+          os[c].write((const char *)buffer[c], samples * sizeof(int16_t));
+        }
+        samples = 0;
+        break;
+      }
+    }
+  }
+
+  et.join();
+  return 0;
+}


### PR DESCRIPTION
Also added the option to disable the built-in beamforming when constructing the MicrophoneArray class.

These changes, I think, would better enable the construction and use of user-defined beamforming algorithms.

Also added a demo that collects raw audio and saves it to disk. Made by copy-and-pasting the micarray_recorder_direct demo and changing a few lines.

Function to access raw audio snatched from https://community.matrix.one/t/getting-raw-data-from-matrix-voice/2537